### PR TITLE
Fix await build error on ios and android

### DIFF
--- a/Xamarin/SSW.Consulting/SSW.Consulting/Services/UserService.cs
+++ b/Xamarin/SSW.Consulting/SSW.Consulting/Services/UserService.cs
@@ -150,7 +150,7 @@ namespace SSW.Consulting.Services
 
         public void SignOut()
         {
-            await Task.Run(Auth.SignOut);
+            Auth.SignOut();
             SecureStorage.RemoveAll();
             Preferences.Clear();
         }


### PR DESCRIPTION
 changed await Task.Run(Auth.SignOut) to Auth.SignOut()